### PR TITLE
Wrap ifThen into StateMachine

### DIFF
--- a/src/StateMachine.test.ts
+++ b/src/StateMachine.test.ts
@@ -1,0 +1,52 @@
+import {input} from "./InputState";
+import {State} from "./State";
+import {IfThen} from "./utils";
+import {StateMachine} from "./StateMachine";
+
+describe("StateMachine", function () {
+
+    it("switching", function () {
+        const automata = new StateMachine<"Init" | "Phase1">();
+
+
+        // switch and value to process differently based on the switch
+        const value = input("result");
+
+        // Output states of value when matching substate is active
+        const whenInit = automata.stateInContext("Init", value);
+        const whenPhase1 = automata.stateInContext("Phase1", value);
+
+        // Initialized with <no value>, so neither stream is active
+        assert.isFalse(whenInit.hasValue());
+        assert.isFalse(whenPhase1.hasValue());
+
+        // Test: switch to valid substate
+        automata.transition("Init");
+
+        // Invalid substate will yield TS error
+        // automata.switch("Unknown"); will result in TS error
+
+
+        // No subscribers -> no downstream values
+        assert.isFalse(whenInit.hasValue());
+        assert.isFalse(whenPhase1.hasValue());
+
+        whenInit.changes$().subscribe();
+        whenPhase1.changes$().subscribe();
+
+        assert.isTrue(whenInit.hasValue());
+        assert.isFalse(whenPhase1.hasValue());
+
+        // Test: switch to Phase1
+        automata.transition("Phase1");
+        assert.isFalse(whenInit.hasValue());
+        assert.isTrue(whenPhase1.hasValue());
+
+        // Reset substate
+        automata.reset();
+        assert.isFalse(whenInit.hasValue());
+        assert.isFalse(whenPhase1.hasValue());
+
+    });
+
+});

--- a/src/StateMachine.ts
+++ b/src/StateMachine.ts
@@ -1,0 +1,20 @@
+import {State} from "./State";
+import {input, InputState} from "./InputState";
+import {IfThen} from "./utils";
+
+export class StateMachine<StateName> {
+
+    private readonly contextSwitch$: InputState<StateName> = input<StateName>();
+
+    public transition(context: StateName) {
+        this.contextSwitch$.putValue(context);
+    }
+
+    public reset(reason?: string) {
+        this.contextSwitch$.clear(reason);
+    }
+
+    public stateInContext<T>(context: StateName, cb: State<T>): State<T> {
+        return IfThen(this.contextSwitch$, s => s === context, cb);
+    }
+}


### PR DESCRIPTION
@romanroe I've experimented with your `ifThen` helper and greatly appreciate it. However, I feel like the number mapping will be less explicit so I added this tiny wrapper around it.

This allows us to properly identify _switching context_ (as I like to call them now) by a type so that you don't have to remember the number associated with your context.
